### PR TITLE
Improved handling of ALLOWED_DOMAINS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Inspired by [BotKit samples for Cisco Spark](https://github.com/CiscoDevNet/botk
 4. Go back to Heroku and scroll down until you reach the **Config Variables** section. Fill them according to the following instructions:
     - **PUBLIC_URL**: Write `https://{app-name}.herokuapp.com` where `{app-name}` is the name of your Heroku app.
     - **SPARK_TOKEN**: The token you got when you created your Spark bot.
-    - **ALLOWED_DOMAIN**: The domain you want to restrict the bot to, in the format `@mydomain.com`.
+    - **ALLOWED_DOMAINS**: A single domain or a commma-separated list of domains you want to restrict the bot to, in the format `mydomain.com` or `mydomain1.com,mydomain2.com`.
     - **ALLOWED_ADMIN**: The Spark username of the person authorized to manage the web application.
     - **SECRET**: Any secret phrase. This is used to validate both Spark's messages to the bot and to generate the authentication tokens used by the app backend.
     - **CLIENT_ID**: The client id you got when creating the integration.

--- a/app.json
+++ b/app.json
@@ -10,8 +10,8 @@
         "SPARK_TOKEN": {
             "description": "The API access token of your Cisco Spark bot."
         },
-        "ALLOWED_DOMAIN": {
-            "description": "The domain from which messages can be received by the bot."
+        "ALLOWED_DOMAINS": {
+            "description": "A single domain or a comma-separated list of domains from which messages can be received by the bot, in format domain.com or domain1.com,domain2.com"
         },
         "ALLOWED_ADMIN": {
             "description": "The Spark email address of the administrator."

--- a/bot.js
+++ b/bot.js
@@ -56,7 +56,7 @@ var controller = Botkit.sparkbot({
     secret: process.env.SECRET, // this is a RECOMMENDED security setting that checks of incoming payloads originate from Cisco Spark
     webhook_name: process.env.WEBHOOK_NAME || ('built with BotKit (' + env + ')'),
     storage: storage,
-    limit_to_domain: process.env.ALLOWED_DOMAIN
+    limit_to_domain: process.env.ALLOWED_DOMAINS.split(",")
 });
 
 var bot = controller.spawn({});


### PR DESCRIPTION
Allowed domains need to accept a list of domains, so it needs to be possible to split a list to form the array the botkit needs.